### PR TITLE
Canary + midi flag info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ This is a monophonic single-oscillator synthesizer I cooked up as an example of 
 
 Check it out, feel free to fork, submit pull requests, etc.
 
+As of June 2014 this works in Chrome Canary after turning on the #enable-web-midi flag in chrome://flags
+
 -Chris


### PR DESCRIPTION
#1 As of June 2014 this works in Chrome Canary after turning on the #enable-web-midi flag in chrome://flags
