### PR TITLE
Fix URL to avoid mixed content warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 	<title>Web MIDI monosynth using Web Audio</title>
 
 	<!-- Set up Web MIDI polyfill -->
-    <script src='//cwilso.github.com/WebMIDIAPIShim/lib/WebMIDIAPI.js'></script>
+    <script src='https://cwilso.github.com/WebMIDIAPIShim/lib/WebMIDIAPI.js'></script>
 
 	<script>
 		/* Copyright 2013 Chris Wilson


### PR DESCRIPTION
```
(index):1 Mixed Content: The page at 'https://webaudiodemos.appspot.com/monosynth/' was loaded over HTTPS, but requested an insecure script 'http://cwilso.github.io/WebMIDIAPIShim/lib/WebMIDIAPI.js'. This request has been blocked; the content must be served over HTTPS.
```